### PR TITLE
Mark student view for multi_device (mobile webview ready)

### DIFF
--- a/done/done.py
+++ b/done/done.py
@@ -54,6 +54,7 @@ class DoneXBlock(XBlock):
 
         return {'state': self.done}
 
+    @XBlock.supports("multi_device")
     def student_view(self, context=None):  # pylint: disable=unused-argument
         """
         The primary view of the DoneXBlock, shown to students


### PR DESCRIPTION
This works fine on mobile in web view, so marking with `supports("multi_device")` decorator. 

# Browsers
## Android, Samsung Galaxy S9 (in Chrome app)
<img width="357" alt="screen shot 2018-08-13 at 4 26 14 pm" src="https://user-images.githubusercontent.com/1289191/44063667-651f0b94-9f16-11e8-8e71-c37b1df1c773.png">

## iPhone X (in Safari app)
<img width="325" alt="screen shot 2018-08-13 at 4 27 22 pm" src="https://user-images.githubusercontent.com/1289191/44063723-abba7da4-9f16-11e8-9df0-e97a2adc066b.png">

# Native Apps

## Android
![screenshot_20180814-121832](https://user-images.githubusercontent.com/1289191/44113577-6814a082-9fbd-11e8-986a-d3ded26492c3.png)
![screenshot_20180814-121837](https://user-images.githubusercontent.com/1289191/44113588-6f679f06-9fbd-11e8-9314-beb835410e0e.png)

## iOS
![img_ece9c09495b2-1](https://user-images.githubusercontent.com/1289191/44165911-d7b3ac00-a07e-11e8-9d69-d01ea456bdd5.jpeg)
