### PR TITLE
[PROD-1440] - Handle fragment DeprecationWarning to reduce logs.

### DIFF
--- a/done/done.py
+++ b/done/done.py
@@ -9,7 +9,7 @@ import six
 import pkg_resources
 from xblock.core import XBlock
 from xblock.fields import Boolean, DateTime, Float, Scope, String
-from xblock.fragment import Fragment
+from web_fragments.fragment import Fragment
 
 
 def resource_string(path):


### PR DESCRIPTION
### [PROD-1440](https://openedx.atlassian.net/browse/PROD-1440)

Reducing logs to free up space in Splunk for a more meaningful history. Handling DeprecationWarning got `fragment`

`DeprecationWarning: xblock.fragment is deprecated. Please use web_fragments.fragment instead`